### PR TITLE
Receive build notifications via Atomist

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -1,0 +1,16 @@
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddJenkinsfileWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.3.49"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs.git"
+    branch: "master"
+    sha: "54d2cc4"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/jenkins"
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.atomist.yml linguist-generated=true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,59 @@
-node {
-        stage('Checkout') {
-            checkout scm
-            echo "cloned"
-        }
+import groovy.json.JsonOutput
 
-        stage('Build') {
-            echo "let's get started"
-            sleep 5
-            echo "almost"
-            sleep 3
-            echo "finished"
-        }
+/*
+ * Retrieve current SCM information from local checkout
+ */
+def getSCMInformation() {
+    def gitRemoteUrl = sh(returnStdout: true, script: 'git config --get remote.origin.url').trim()
+    def gitCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+    def gitBranchName = sh(returnStdout: true, script: 'git name-rev --always --name-only HEAD').trim().replace('remotes/origin/', '')
+
+    return [
+        url: gitRemoteUrl,
+        branch: gitBranchName,
+        commit: gitCommitSha
+    ]
+}
+
+/*
+ * Notify the Atomist services about the status of a build based from a
+ * git repository.
+ */
+def notifyAtomist(buildStatus, buildPhase="FINALIZED",
+                  endpoint="https://webhook.atomist.com/atomist/jenkins") {
+
+    def payload = JsonOutput.toJson([
+        name: env.JOB_NAME,
+        duration: currentBuild.duration,
+        build      : [
+            number: env.BUILD_NUMBER,
+            phase: buildPhase,
+            status: buildStatus,
+            full_url: env.BUILD_URL,
+            scm: getSCMInformation()
+        ]
+    ])
+
+    sh "curl --silent -XPOST -H 'Content-Type: application/json' -d '${payload}' ${endpoint}"
+}
+node {
+    try {
+        stage('Checkout') {
+                checkout scm
+                notifyAtomist("STARTED", "STARTED")
+                echo "cloned"
+            }
+
+            stage('Build') {
+                echo "let's get started"
+                sleep 5
+                echo "almost"
+                sleep 3
+                echo "finished"
+            }
+        notifyAtomist("SUCCESS")
+    } catch(e) {
+        notifyAtomist("FAILURE")
+        throw e
+    }
 }


### PR DESCRIPTION
Send build events to Atomist.

They'll be incorporated into GitHub push and PR notifications,
so you'll see dynamically updated build results along with your commits.
Look for them in #goat in Slack.

[Atomist jenkinsfile documentation](http://docs.atomist.com/getting-started/jenkins/#jenkinsfile)